### PR TITLE
Prevent race of contidion from panic

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.1.0: QmaDNZ4QMdBdku1YZWBysufYyoQt1negQGNav6PLYarbY8
+1.1.1: QmYtB7Qge8cJpXc4irsEp8zRqfnZMBeB7aTrMEkPk67DRv

--- a/package.json
+++ b/package.json
@@ -23,5 +23,5 @@
   "language": "go",
   "license": "",
   "name": "go-log",
-  "version": "1.1.0"
+  "version": "1.1.1"
 }

--- a/writer.go
+++ b/writer.go
@@ -230,7 +230,9 @@ func (bw *bufWriter) loop() {
 			if bufsize > MaxWriterBuffer {
 				// if we have too many messages buffered, kill the writer
 				bw.die()
-				close(nextCh)
+				if nextCh != nil {
+					close(nextCh)
+				}
 				nextCh = nil
 				// explicity keep going here to drain incoming
 			}


### PR DESCRIPTION
Due to race of condition nextCh can be already null when we try to close it
Resolves https://github.com/ipfs/go-ipfs/issues/2732