### PR TITLE
Use forked opentracing-go

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.3.1: QmWtgEzaDQH5MMTgfnzzJA9amdD2xWqaMZCULusk4jEmBW
+1.3.2: QmeMFK13EDShD6L5dvrE9TEiuqtqRMBfxpgNkGxUYY4Vk5

--- a/log.go
+++ b/log.go
@@ -9,9 +9,9 @@ import (
 	"fmt"
 	"time"
 
-	opentrace "github.com/opentracing/opentracing-go"
-	otExt "github.com/opentracing/opentracing-go/ext"
-	otl "github.com/opentracing/opentracing-go/log"
+	opentrace "github.com/frrist/opentracing-go"
+	otExt "github.com/frrist/opentracing-go/ext"
+	otl "github.com/frrist/opentracing-go/log"
 )
 
 // StandardLogger provides API compatibility with standard printf loggers

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     },
     {
       "author": "forrestweston",
-      "hash": "QmYdApJEk7WcDz8mhbYrosKKbHxcP5thozoVe6fxaLwoXg",
+      "hash": "QmNzrrMTk2FKTAE66aVkbskzprpojeQaNJGid9xYVU3xAs",
       "name": "opentracing-go",
       "version": "0.0.0"
     }
@@ -22,6 +22,6 @@
   "language": "go",
   "license": "",
   "name": "go-log",
-  "version": "1.3.1"
+  "version": "1.3.2"
 }
 


### PR DESCRIPTION
opentracing-go is targeting support for go1.6 becasue of that we must
use a forked version that uses the latest context package
