### PR TITLE
update opentracing-go to fix imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     },
     {
       "author": "forrestweston",
-      "hash": "QmNzrrMTk2FKTAE66aVkbskzprpojeQaNJGid9xYVU3xAs",
+      "hash": "QmTK5zDUX4diGfA8ksDEdTcfwYZqGjLKBpFM8Ei1Niferw",
       "name": "opentracing-go",
-      "version": "0.0.0"
+      "version": "0.0.1"
     }
   ],
   "gxVersion": "0.7.0",


### PR DESCRIPTION
The previous commit switched to a forked opentracing build but the forked version still had imports pointing to the original version.

This commit updates the forked version of opentracing-go to one with fixed imports.