### PR TITLE
fix call stack problem for logging on go1.10

### DIFF
--- a/oldlog.go
+++ b/oldlog.go
@@ -121,7 +121,7 @@ func GetSubsystems() []string {
 
 func getLogger(name string) *logging.Logger {
 	log := logging.MustGetLogger(name)
-	log.ExtraCalldepth = 1
+	log.ExtraCalldepth = 0 
 	loggers[name] = log
 	return log
 }


### PR DESCRIPTION
The wrong debug output for swarm2 is swarm_listen.go:99 such as:
DEBUG     swarm2: Swarm Listeners at [/ip4/127.0.0.1/tcp/10012] swarm_listen.go:99

If we change  log.ExtraCalldepth to 0, the output will be correct
DEBUG     swarm2: Swarm Listeners at [/ip4/127.0.0.1/tcp/10012] swarm_listen.go:109