### PR TITLE
remove unnecessary ExtraCalldepth

### DIFF
--- a/oldlog.go
+++ b/oldlog.go
@@ -121,7 +121,6 @@ func GetSubsystems() []string {
 
 func getLogger(name string) *logging.Logger {
 	log := logging.MustGetLogger(name)
-	log.ExtraCalldepth = 1
 	loggers[name] = log
 	return log
 }


### PR DESCRIPTION
This was messing with the line numbers. It was reported and fixed in #33 but that PR isn't formatted.

closes #33

(all credit goes to @jiangsong)