### PR TITLE
gx publish 1.5.6

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.5.5: QmRREK2CAZ5Re2Bd9zZFG6FeYDppUWt5cMgsoUEp3ktgSr
+1.5.6: Qmbq7kGxgcpALGLPaWDyTa6KUq5kBUKdEvkvPZcBkJoLex

--- a/package.json
+++ b/package.json
@@ -1,17 +1,19 @@
 {
-  "bugs": {},
+  "bugs": {
+    "url": "https://github.com/ipfs/go-log"
+  },
   "gx": {
     "dvcsimport": "github.com/ipfs/go-log"
   },
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "QmQvJiADDe7JR4m968MwXobTCCzUqQkP87aRHe29MEBGHV",
+      "hash": "QmcaSwFc5RBg8yCq54QURwEU4nwjfCpjbpmaAm4VbdGLKv",
       "name": "go-logging",
       "version": "0.0.0"
     },
     {
-      "author": "forrestweston",
+      "author": "frist",
       "hash": "QmWLWmRVSiagqP15jczsGME1qpob6HDbtbHAY2he9W5iUo",
       "name": "opentracing-go",
       "version": "0.0.3"
@@ -29,11 +31,11 @@
       "version": "0.0.0"
     }
   ],
-  "gxVersion": "0.7.0",
-  "issues_url": "",
+  "gxVersion": "0.12.1",
   "language": "go",
   "license": "",
   "name": "go-log",
-  "version": "1.5.5"
+  "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
+  "version": "1.5.6"
 }
 


### PR DESCRIPTION
This updates go-logging to latest github.com/whyrusleeping/go-logging master, which has a fix for a race in `SetLevel()` which I am hitting when running with `-race`.

Upgraded package.json to latest format too.