### PR TITLE
make logging prettier

### DIFF
--- a/log.go
+++ b/log.go
@@ -336,13 +336,17 @@ func (el *eventLogger) Event(ctx context.Context, event string, metadata ...Logg
 	accum["system"] = e.system
 	accum["time"] = FormatRFC3339(time.Now())
 
-	out, err := json.Marshal(accum)
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	err = encoder.Encode(accum)
 	if err != nil {
 		el.Errorf("ERROR FORMATTING EVENT ENTRY: %s", err)
 		return
 	}
 
-	writer.WriterGroup.Write(append(out, '\n'))
+	writer.WriterGroup.Write(buf.Bytes())
 }
 
 // DEPRECATED


### PR DESCRIPTION
1. Pretty format the JSON.
2. Manually convert tag values. According to the opentracing spec, these are only supposed to be strings, ints, and booleans. We were using the standard MarshalJSON interface which was trying to marshal our peer IDs as raw byte strings.