### PR TITLE
uglify the (event) logs

### DIFF
--- a/log.go
+++ b/log.go
@@ -339,7 +339,6 @@ func (el *eventLogger) Event(ctx context.Context, event string, metadata ...Logg
 	var buf bytes.Buffer
 	encoder := json.NewEncoder(&buf)
 	encoder.SetEscapeHTML(false)
-	encoder.SetIndent("", "  ")
 	err = encoder.Encode(accum)
 	if err != nil {
 		el.Errorf("ERROR FORMATTING EVENT ENTRY: %s", err)

--- a/tracer/recorder.go
+++ b/tracer/recorder.go
@@ -93,7 +93,6 @@ func (r *LoggableSpanRecorder) RecordSpan(span RawSpan) {
 	var buf bytes.Buffer
 	encoder := json.NewEncoder(&buf)
 	encoder.SetEscapeHTML(false)
-	encoder.SetIndent("", "  ")
 	err := encoder.Encode(spanlog)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR FORMATTING SPAN ENTRY: %s\n", err)


### PR DESCRIPTION
So, it turns out js-ipfs-api is relying on the fact that go-ipfs spits out ndjson event logs. Furthermore, it turns out that ndjson is just generally easier to parse. Therefore, while pretty logs are pretty, I think it's best to leave this up to the client.