### PR TITLE
Deprecate EventLogging and Warning* functions

### DIFF
--- a/log.go
+++ b/log.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	writer "github.com/ipfs/go-log/writer"
+	"github.com/whyrusleeping/go-logging"
 
 	opentrace "github.com/opentracing/opentracing-go"
 	otExt "github.com/opentracing/opentracing-go/ext"
@@ -36,15 +37,14 @@ type StandardLogger interface {
 	Warning(args ...interface{})
 	// Deprecated use Warnf
 	Warningf(format string, args ...interface{})
+	Warn(args ...interface{})
+	Warnf(format string, args ...interface{})
 }
 
 // EventLogger extends the StandardLogger interface to allow for log items
 // containing structured metadata
 type EventLogger interface {
 	StandardLogger
-
-	Warn(args ...interface{})
-	Warnf(format string, args ...interface{})
 
 	// Event merges structured data from the provided inputs into a single
 	// machine-readable log event.
@@ -172,12 +172,12 @@ func Logger(system string) EventLogger {
 
 	logger := getLogger(system)
 
-	return &eventLogger{system: system, StandardLogger: logger}
+	return &eventLogger{system: system, Logger: *logger}
 }
 
 // eventLogger implements the EventLogger and wraps a go-logging Logger
 type eventLogger struct {
-	StandardLogger
+	logging.Logger
 
 	system string
 	// TODO add log-level

--- a/log.go
+++ b/log.go
@@ -32,7 +32,9 @@ type StandardLogger interface {
 	Infof(format string, args ...interface{})
 	Panic(args ...interface{})
 	Panicf(format string, args ...interface{})
+	// Deprecated use Warn
 	Warning(args ...interface{})
+	// Deprecated use Warnf
 	Warningf(format string, args ...interface{})
 }
 
@@ -40,6 +42,9 @@ type StandardLogger interface {
 // containing structured metadata
 type EventLogger interface {
 	StandardLogger
+
+	Warn(args ...interface{})
+	Warnf(format string, args ...interface{})
 
 	// Event merges structured data from the provided inputs into a single
 	// machine-readable log event.
@@ -176,6 +181,13 @@ type eventLogger struct {
 
 	system string
 	// TODO add log-level
+}
+
+func (el *eventLogger) Warn(args ...interface{}) {
+	el.Warning(args...)
+}
+func (el *eventLogger) Warnf(format string, args ...interface{}) {
+	el.Warningf(format, args...)
 }
 
 // Deprecated: Stop using go-log for event logging

--- a/log.go
+++ b/log.go
@@ -55,9 +55,11 @@ type EventLogger interface {
 	// Finally the timestamp and package name are added to the accumulator and
 	// the metadata is logged.
 	// DEPRECATED
+	// Deprecated: Stop using go-log for event logging
 	Event(ctx context.Context, event string, m ...Loggable)
 
 	// DEPRECATED
+	// Deprecated: Stop using go-log for event logging
 	EventBegin(ctx context.Context, event string, m ...Loggable) *EventInProgress
 
 	// Start starts an opentracing span with `name`, using
@@ -74,6 +76,7 @@ type EventLogger interface {
 	//        defer log.Finish(ctx)
 	//        ...
 	//    }
+	// Deprecated: Stop using go-log for event logging
 	Start(ctx context.Context, name string) context.Context
 
 	// StartFromParentState starts an opentracing span with `name`, using
@@ -95,6 +98,7 @@ type EventLogger interface {
 	//        defer log.Finish(ctx)
 	//        ...
 	//    }
+	// Deprecated: Stop using go-log for event logging
 	StartFromParentState(ctx context.Context, name string, parent []byte) (context.Context, error)
 
 	// Finish completes the span associated with `ctx`.
@@ -103,6 +107,7 @@ type EventLogger interface {
 	// otherwise leads to undefined behavior.
 	// Finish will do its best to notify (log) when used in correctly
 	//		.e.g called twice, or called on a spanless `ctx`
+	// Deprecated: Stop using go-log for event logging
 	Finish(ctx context.Context)
 
 	// FinishWithErr completes the span associated with `ctx` and also calls
@@ -112,10 +117,12 @@ type EventLogger interface {
 	// otherwise leads to undefined behavior.
 	// FinishWithErr will do its best to notify (log) when used in correctly
 	//		.e.g called twice, or called on a spanless `ctx`
+	// Deprecated: Stop using go-log for event logging
 	FinishWithErr(ctx context.Context, err error)
 
 	// SetErr tags the span associated with `ctx` to reflect an error occured, and
 	// logs the value `err` under key `error`.
+	// Deprecated: Stop using go-log for event logging
 	SetErr(ctx context.Context, err error)
 
 	// LogKV records key:value logging data about an event stored in `ctx`
@@ -124,9 +131,11 @@ type EventLogger interface {
 	//        "error", "resolve failure",
 	//        "type", "cache timeout",
 	//        "waited.millis", 1500)
+	// Deprecated: Stop using go-log for event logging
 	LogKV(ctx context.Context, alternatingKeyValues ...interface{})
 
 	// SetTag tags key `k` and value `v` on the span associated with `ctx`
+	// Deprecated: Stop using go-log for event logging
 	SetTag(ctx context.Context, key string, value interface{})
 
 	// SetTags tags keys from the `tags` maps on the span associated with `ctx`
@@ -135,11 +144,13 @@ type EventLogger interface {
 	//		"type": bizStruct,
 	//      "request": req,
 	//		})
+	// Deprecated: Stop using go-log for event logging
 	SetTags(ctx context.Context, tags map[string]interface{})
 
 	// SerializeContext takes the SpanContext instance stored in `ctx` and Seralizes
 	// it to bytes. An error is returned if the `ctx` cannot be serialized to
 	// a bytes array
+	// Deprecated: Stop using go-log for event logging
 	SerializeContext(ctx context.Context) ([]byte, error)
 }
 
@@ -167,12 +178,14 @@ type eventLogger struct {
 	// TODO add log-level
 }
 
+// Deprecated: Stop using go-log for event logging
 func (el *eventLogger) Start(ctx context.Context, operationName string) context.Context {
 	span, ctx := opentrace.StartSpanFromContext(ctx, operationName)
 	span.SetTag("system", el.system)
 	return ctx
 }
 
+// Deprecated: Stop using go-log for event logging
 func (el *eventLogger) StartFromParentState(ctx context.Context, operationName string, parent []byte) (context.Context, error) {
 	sc, err := deserializeContext(parent)
 	if err != nil {
@@ -185,6 +198,7 @@ func (el *eventLogger) StartFromParentState(ctx context.Context, operationName s
 	return ctx, nil
 }
 
+// Deprecated: Stop using go-log for event logging
 func (el *eventLogger) SerializeContext(ctx context.Context) ([]byte, error) {
 	gTracer := opentrace.GlobalTracer()
 	b := make([]byte, 0)
@@ -196,6 +210,7 @@ func (el *eventLogger) SerializeContext(ctx context.Context) ([]byte, error) {
 	return carrier.Bytes(), nil
 }
 
+// Deprecated: Stop using go-log for event logging
 func (el *eventLogger) LogKV(ctx context.Context, alternatingKeyValues ...interface{}) {
 	span := opentrace.SpanFromContext(ctx)
 	if span == nil {
@@ -206,6 +221,7 @@ func (el *eventLogger) LogKV(ctx context.Context, alternatingKeyValues ...interf
 	span.LogKV(alternatingKeyValues...)
 }
 
+// Deprecated: Stop using go-log for event logging
 func (el *eventLogger) SetTag(ctx context.Context, k string, v interface{}) {
 	span := opentrace.SpanFromContext(ctx)
 	if span == nil {
@@ -216,6 +232,7 @@ func (el *eventLogger) SetTag(ctx context.Context, k string, v interface{}) {
 	span.SetTag(k, v)
 }
 
+// Deprecated: Stop using go-log for event logging
 func (el *eventLogger) SetTags(ctx context.Context, tags map[string]interface{}) {
 	span := opentrace.SpanFromContext(ctx)
 	if span == nil {
@@ -243,10 +260,12 @@ func (el *eventLogger) setErr(ctx context.Context, err error, skip int) {
 	span.LogKV("error", err.Error())
 }
 
+// Deprecated: Stop using go-log for event logging
 func (el *eventLogger) SetErr(ctx context.Context, err error) {
 	el.setErr(ctx, err, 1)
 }
 
+// Deprecated: Stop using go-log for event logging
 func (el *eventLogger) Finish(ctx context.Context) {
 	span := opentrace.SpanFromContext(ctx)
 	if span == nil {
@@ -257,6 +276,7 @@ func (el *eventLogger) Finish(ctx context.Context) {
 	span.Finish()
 }
 
+// Deprecated: Stop using go-log for event logging
 func (el *eventLogger) FinishWithErr(ctx context.Context, err error) {
 	el.setErr(ctx, err, 2)
 	el.Finish(ctx)
@@ -273,7 +293,7 @@ func deserializeContext(bCtx []byte) (opentrace.SpanContext, error) {
 	return spanContext, nil
 }
 
-// DEPRECATED use `Start`
+// Deprecated: Stop using go-log for event logging
 func (el *eventLogger) EventBegin(ctx context.Context, event string, metadata ...Loggable) *EventInProgress {
 	ctx = el.Start(ctx, event)
 
@@ -301,7 +321,7 @@ type activeEventKeyType struct{}
 
 var activeEventKey = activeEventKeyType{}
 
-// DEPRECATED use `Start`
+// Deprecated: Stop using go-log for event logging
 func (el *eventLogger) Event(ctx context.Context, event string, metadata ...Loggable) {
 
 	// short circuit if theres nothing to write to
@@ -354,6 +374,7 @@ func (el *eventLogger) Event(ctx context.Context, event string, metadata ...Logg
 
 // DEPRECATED
 // EventInProgress represent and event which is happening
+// Deprecated: Stop using go-log for event logging
 type EventInProgress struct {
 	loggables []Loggable
 	doneFunc  func([]Loggable)
@@ -373,9 +394,9 @@ func (eip *EventInProgress) SetError(err error) {
 	})
 }
 
-// DEPRECATED use `Finish`
 // Done creates a new Event entry that includes the duration and appended
 // loggables.
+// Deprecated: Stop using go-log for event logging
 func (eip *EventInProgress) Done() {
 	eip.doneFunc(eip.loggables) // create final event with extra data
 }
@@ -391,8 +412,8 @@ func (eip *EventInProgress) DoneWithErr(err error) {
 	eip.doneFunc(eip.loggables)
 }
 
-// DEPRECATED use `Finish`
 // Close is an alias for done
+// Deprecated: Stop using go-log for event logging
 func (eip *EventInProgress) Close() error {
 	eip.Done()
 	return nil


### PR DESCRIPTION
This is first set toward migrating this pacakage away from event logging and
toward Zap.

The aim is for this pacakge to be a manager for Zap loggers.