### PR TITLE
fix go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ipfs/go-log
+module github.com/ipfs/go-log/v2
 
 require (
 	github.com/gogo/protobuf v1.2.1


### PR DESCRIPTION
Failed to add `v2` to go.mod file.