### PR TITLE
Remove Warningf method signature from StandardLogger

### DIFF
--- a/log.go
+++ b/log.go
@@ -24,7 +24,6 @@ type StandardLogger interface {
 	Infof(format string, args ...interface{})
 	Panic(args ...interface{})
 	Panicf(format string, args ...interface{})
-	Warningf(format string, args ...interface{})
 	Warn(args ...interface{})
 	Warnf(format string, args ...interface{})
 }


### PR DESCRIPTION
Remove `Warningf` method from `StandardLogger` interface to fix error:

`# ***/vendor/github.com/libp2p/go-reuseport/singlepoll
vendor/github.com/libp2p/go-reuseport/singlepoll/linux.go:22:2: cannot use log.Logger("reuseport-poll") (type *log.ZapEventLogger) as type log.EventLogger in assignment:
	*log.ZapEventLogger does not implement log.EventLogger (missing Warningf method)`

This error shows up in `v2.0.1` after https://github.com/ipfs/go-log/commit/eede8da5989fa4a4e2408ca2070bb12529954db0 has been merged.