### PR TITLE
Add log config and populate from environment

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -18,7 +18,7 @@ func init() {
 		return pipes, nil
 	})
 
-	SetupLogging()
+	SetupLogging(ConfigFromEnv())
 }
 
 // Logging environment variables
@@ -37,6 +37,60 @@ const (
 	envLoggingFile = "GOLOG_FILE" // /path/to/file
 )
 
+type Config struct {
+	// Format overrides the format of the log output. Defaults to ColorizedOutput
+	Format LogFormat
+
+	// Level is the minimum enabled logging level.
+	Level string
+
+	// Stderr indicates whether logs should be written to stderr.
+	Stderr bool
+
+	// Stdout indicates whether logs should be written to stdout.
+	Stdout bool
+
+	// File is a path to a file that logs will be written to.
+	File string
+}
+
+// ConfigFromEnv returns a Config with defaults populated using environment variables.
+func ConfigFromEnv() Config {
+	cfg := Config{
+		Format: ColorizedOutput,
+		Stderr: true,
+	}
+
+	format := os.Getenv(envLoggingFmt)
+	if format == "" {
+		format = os.Getenv(envIPFSLoggingFmt)
+	}
+
+	switch format {
+	case "nocolor":
+		cfg.Format = PlaintextOutput
+	case "json":
+		cfg.Format = JSONOutput
+	}
+
+	cfg.Level = os.Getenv(envLogging)
+	if cfg.Level == "" {
+		cfg.Level = os.Getenv(envIPFSLogging)
+	}
+
+	cfg.File = os.Getenv(envLoggingFile)
+
+	return cfg
+}
+
+type LogFormat int
+
+const (
+	ColorizedOutput LogFormat = iota
+	PlaintextOutput
+	JSONOutput
+)
+
 // ErrNoSuchLogger is returned when the util pkg is asked for a non existant logger
 var ErrNoSuchLogger = errors.New("Error: No such logger")
 
@@ -45,23 +99,19 @@ var loggerMutex sync.RWMutex
 var loggers = make(map[string]*zap.SugaredLogger)
 var levels = make(map[string]zap.AtomicLevel)
 
+var zapCfg = zap.NewProductionConfig()
+
 // SetupLogging will initialize the logger backend and set the flags.
 // TODO calling this in `init` pushes all configuration to env variables
 // - move it out of `init`? then we need to change all the code (js-ipfs, go-ipfs) to call this explicitly
 // - have it look for a config file? need to define what that is
-var zapCfg = zap.NewProductionConfig()
-
-func SetupLogging() {
-	loggingFmt := os.Getenv(envLoggingFmt)
-	if loggingFmt == "" {
-		loggingFmt = os.Getenv(envIPFSLoggingFmt)
-	}
+func SetupLogging(cfg Config) {
 	// colorful or plain
-	switch loggingFmt {
-	case "nocolor":
+	switch cfg.Format {
+	case PlaintextOutput:
 		zapCfg.Encoding = "console"
 		zapCfg.EncoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
-	case "json":
+	case JSONOutput:
 		zapCfg.Encoding = "json"
 	default:
 		zapCfg.Encoding = "console"
@@ -72,27 +122,29 @@ func SetupLogging() {
 	zapCfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	zapCfg.DisableStacktrace = true
 
-	zapCfg.OutputPaths = []string{"stderr", "pipes://"}
+	zapCfg.OutputPaths = []string{"pipes://"}
+
+	if cfg.Stderr {
+		zapCfg.OutputPaths = append(zapCfg.OutputPaths, "stderr")
+	}
+	if cfg.Stdout {
+		zapCfg.OutputPaths = append(zapCfg.OutputPaths, "stdout")
+	}
+
 	// check if we log to a file
-	if logfp := os.Getenv(envLoggingFile); len(logfp) > 0 {
-		if path, err := normalizePath(logfp); err != nil {
-			fmt.Fprintf(os.Stderr, "failed to resolve log path '%q', logging to stderr only: %s\n", logfp, err)
+	if len(cfg.File) > 0 {
+		if path, err := normalizePath(cfg.File); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to resolve log path '%q', logging to stderr only: %s\n", cfg.File, err)
 		} else {
 			zapCfg.OutputPaths = append(zapCfg.OutputPaths, path)
 		}
 	}
 
-	// set the backend(s)
 	lvl := LevelError
 
-	logenv := os.Getenv(envLogging)
-	if logenv == "" {
-		logenv = os.Getenv(envIPFSLogging)
-	}
-
-	if logenv != "" {
+	if cfg.Level != "" {
 		var err error
-		lvl, err = LevelFromString(logenv)
+		lvl, err = LevelFromString(cfg.Level)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error setting log levels: %s\n", err)
 		}


### PR DESCRIPTION
This change adds a Config struct to enable easier reconfiguration
of the logger. The default config is still read from the
environment in init() but a client of the package can now call
SetupLogging again with a custom config to adjust logging after
initialization.

Allows logging to stderr to be disabled via configuration.

Fixes https://github.com/ipfs/go-log/issues/83