### PR TITLE
Use multiple cores in logger

### DIFF
--- a/core.go
+++ b/core.go
@@ -1,0 +1,120 @@
+package log
+
+import (
+	"sync"
+
+	"go.uber.org/multierr"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+var _ zapcore.Core = (*lockedMultiCore)(nil)
+
+type lockedMultiCore struct {
+	mu    sync.RWMutex // guards mutations to cores slice
+	cores []zapcore.Core
+}
+
+func (l *lockedMultiCore) With(fields []zapcore.Field) zapcore.Core {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	sub := &lockedMultiCore{
+		cores: make([]zapcore.Core, len(l.cores)),
+	}
+	for i := range l.cores {
+		sub.cores[i] = l.cores[i].With(fields)
+	}
+	return sub
+}
+
+func (l *lockedMultiCore) Enabled(lvl zapcore.Level) bool {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	for i := range l.cores {
+		if l.cores[i].Enabled(lvl) {
+			return true
+		}
+	}
+	return false
+}
+
+func (l *lockedMultiCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	for i := range l.cores {
+		ce = l.cores[i].Check(ent, ce)
+	}
+	return ce
+}
+
+func (l *lockedMultiCore) Write(ent zapcore.Entry, fields []zapcore.Field) error {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	var err error
+	for i := range l.cores {
+		err = multierr.Append(err, l.cores[i].Write(ent, fields))
+	}
+	return err
+}
+
+func (l *lockedMultiCore) Sync() error {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	var err error
+	for i := range l.cores {
+		err = multierr.Append(err, l.cores[i].Sync())
+	}
+	return err
+}
+
+func (l *lockedMultiCore) AddCore(core zapcore.Core) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.cores = append(l.cores, core)
+}
+
+func (l *lockedMultiCore) DeleteCore(core zapcore.Core) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	w := 0
+	for i := 0; i < len(l.cores); i++ {
+		if l.cores[i] == core {
+			continue
+		}
+		l.cores[w] = l.cores[i]
+		w++
+	}
+	l.cores = l.cores[:w]
+}
+
+func (l *lockedMultiCore) ReplaceCore(original, replacement zapcore.Core) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	for i := 0; i < len(l.cores); i++ {
+		if l.cores[i] == original {
+			l.cores[i] = replacement
+		}
+	}
+}
+
+func newCore(format LogFormat, ws zapcore.WriteSyncer, level LogLevel) zapcore.Core {
+	encCfg := zap.NewProductionEncoderConfig()
+	encCfg.EncodeTime = zapcore.ISO8601TimeEncoder
+
+	var encoder zapcore.Encoder
+	switch format {
+	case PlaintextOutput:
+		encCfg.EncodeLevel = zapcore.CapitalLevelEncoder
+		encoder = zapcore.NewConsoleEncoder(encCfg)
+	case JSONOutput:
+		encoder = zapcore.NewJSONEncoder(encCfg)
+	default:
+		encCfg.EncodeLevel = zapcore.CapitalColorLevelEncoder
+		encoder = zapcore.NewConsoleEncoder(encCfg)
+	}
+
+	return zapcore.NewCore(encoder, ws, zap.NewAtomicLevelAt(zapcore.Level(level)))
+}

--- a/core_test.go
+++ b/core_test.go
@@ -1,0 +1,177 @@
+package log
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"go.uber.org/zap/zapcore"
+)
+
+func TestNewCoreFormat(t *testing.T) {
+	entry := zapcore.Entry{
+		LoggerName: "main",
+		Level:      zapcore.InfoLevel,
+		Message:    "scooby",
+		Time:       time.Date(2010, 5, 23, 15, 14, 0, 0, time.UTC),
+	}
+
+	testCases := []struct {
+		format LogFormat
+		want   string
+	}{
+		{
+			format: ColorizedOutput,
+			want:   "2010-05-23T15:14:00.000Z\t\x1b[34mINFO\x1b[0m\tmain\tscooby\n",
+		},
+		{
+			format: JSONOutput,
+			want:   `{"level":"info","ts":"2010-05-23T15:14:00.000Z","logger":"main","msg":"scooby"}` + "\n",
+		},
+		{
+			format: PlaintextOutput,
+			want:   "2010-05-23T15:14:00.000Z\tINFO\tmain\tscooby\n",
+		},
+	}
+
+	for _, tc := range testCases {
+		buf := &bytes.Buffer{}
+		ws := zapcore.AddSync(buf)
+
+		core := newCore(tc.format, ws, LevelDebug)
+		core.Write(entry, nil)
+
+		got := buf.String()
+		if got != tc.want {
+			t.Errorf("got %q, want %q", got, tc.want)
+		}
+	}
+
+}
+
+func TestLockedMultiCoreAddCore(t *testing.T) {
+	mc := &lockedMultiCore{}
+
+	buf1 := &bytes.Buffer{}
+	core1 := newCore(PlaintextOutput, zapcore.AddSync(buf1), LevelDebug)
+	mc.AddCore(core1)
+
+	buf2 := &bytes.Buffer{}
+	core2 := newCore(ColorizedOutput, zapcore.AddSync(buf2), LevelDebug)
+	mc.AddCore(core2)
+
+	entry := zapcore.Entry{
+		LoggerName: "main",
+		Level:      zapcore.InfoLevel,
+		Message:    "scooby",
+		Time:       time.Date(2010, 5, 23, 15, 14, 0, 0, time.UTC),
+	}
+	mc.Write(entry, nil)
+
+	want1 := "2010-05-23T15:14:00.000Z\tINFO\tmain\tscooby\n"
+	got1 := buf1.String()
+	if got1 != want1 {
+		t.Errorf("core1 got %q, want %q", got1, want1)
+	}
+
+	want2 := "2010-05-23T15:14:00.000Z\t\x1b[34mINFO\x1b[0m\tmain\tscooby\n"
+	got2 := buf2.String()
+	if got2 != want2 {
+		t.Errorf("core2 got %q, want %q", got2, want2)
+	}
+
+}
+
+func TestLockedMultiCoreDeleteCore(t *testing.T) {
+
+	mc := &lockedMultiCore{}
+
+	buf1 := &bytes.Buffer{}
+	core1 := newCore(PlaintextOutput, zapcore.AddSync(buf1), LevelDebug)
+	mc.AddCore(core1)
+
+	// Write entry to just first core
+	entry := zapcore.Entry{
+		LoggerName: "main",
+		Level:      zapcore.InfoLevel,
+		Message:    "scooby",
+		Time:       time.Date(2010, 5, 23, 15, 14, 0, 0, time.UTC),
+	}
+	mc.Write(entry, nil)
+
+	buf2 := &bytes.Buffer{}
+	core2 := newCore(ColorizedOutput, zapcore.AddSync(buf2), LevelDebug)
+	mc.AddCore(core2)
+
+	// Remove the first core
+	mc.DeleteCore(core1)
+
+	// Write another entry
+	entry2 := zapcore.Entry{
+		LoggerName: "main",
+		Level:      zapcore.InfoLevel,
+		Message:    "velma",
+		Time:       time.Date(2010, 5, 23, 15, 15, 0, 0, time.UTC),
+	}
+
+	mc.Write(entry2, nil)
+
+	want1 := "2010-05-23T15:14:00.000Z\tINFO\tmain\tscooby\n"
+	got1 := buf1.String()
+	if got1 != want1 {
+		t.Errorf("core1 got %q, want %q", got1, want1)
+	}
+
+	want2 := "2010-05-23T15:15:00.000Z\t\x1b[34mINFO\x1b[0m\tmain\tvelma\n"
+	got2 := buf2.String()
+	if got2 != want2 {
+		t.Errorf("core2 got %q, want %q", got2, want2)
+	}
+
+}
+
+func TestLockedMultiCoreReplaceCore(t *testing.T) {
+	mc := &lockedMultiCore{}
+
+	buf1 := &bytes.Buffer{}
+	core1 := newCore(PlaintextOutput, zapcore.AddSync(buf1), LevelDebug)
+	mc.AddCore(core1)
+
+	// Write entry to just first core
+	entry := zapcore.Entry{
+		LoggerName: "main",
+		Level:      zapcore.InfoLevel,
+		Message:    "scooby",
+		Time:       time.Date(2010, 5, 23, 15, 14, 0, 0, time.UTC),
+	}
+	mc.Write(entry, nil)
+
+	buf2 := &bytes.Buffer{}
+	core2 := newCore(ColorizedOutput, zapcore.AddSync(buf2), LevelDebug)
+
+	// Replace the first core with the second
+	mc.ReplaceCore(core1, core2)
+
+	// Write another entry
+	entry2 := zapcore.Entry{
+		LoggerName: "main",
+		Level:      zapcore.InfoLevel,
+		Message:    "velma",
+		Time:       time.Date(2010, 5, 23, 15, 15, 0, 0, time.UTC),
+	}
+
+	mc.Write(entry2, nil)
+
+	want1 := "2010-05-23T15:14:00.000Z\tINFO\tmain\tscooby\n"
+	got1 := buf1.String()
+	if got1 != want1 {
+		t.Errorf("core1 got %q, want %q", got1, want1)
+	}
+
+	want2 := "2010-05-23T15:15:00.000Z\t\x1b[34mINFO\x1b[0m\tmain\tvelma\n"
+	got2 := buf2.String()
+	if got2 != want2 {
+		t.Errorf("core2 got %q, want %q", got2, want2)
+	}
+
+}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
 module github.com/ipfs/go-log/v2
 
-require go.uber.org/zap v1.14.1
+require (
+	go.uber.org/multierr v1.5.0
+	go.uber.org/zap v1.14.1
+)
 
 go 1.12

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,7 @@ go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee h1:0mgffUl7nfd+FpvXMVz4IDEa
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9Ejo0C68/HhF8uaILCdgjnY+goOA=
 go.uber.org/zap v1.14.1 h1:nYDKopTbvAPq/NrUVZwT15y2lpROBiLLyoRTbXOYWOo=
 go.uber.org/zap v1.14.1/go.mod h1:Mb2vm2krFEG5DV0W9qcHBYFtp/Wku1cvYaqPsS/WYfc=
+go.uber.org/zap v1.15.0 h1:ZZCA22JRF2gQE5FoNmhmrf7jeJJ2uhqDUNRYKm8dvmM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA6JiaEZDtJb9Ei+1LlBs=

--- a/pipe.go
+++ b/pipe.go
@@ -37,7 +37,7 @@ func NewPipeReader(opts ...PipeReaderOption) *PipeReader {
 	loggerMutex.Unlock()
 
 	for _, o := range opts {
-		o.SetOption(&opt)
+		o.setOption(&opt)
 	}
 
 	r, w := io.Pipe()
@@ -58,12 +58,12 @@ type pipeReaderOptions struct {
 }
 
 type PipeReaderOption interface {
-	SetOption(*pipeReaderOptions)
+	setOption(*pipeReaderOptions)
 }
 
 type pipeReaderOptionFunc func(*pipeReaderOptions)
 
-func (p pipeReaderOptionFunc) SetOption(o *pipeReaderOptions) {
+func (p pipeReaderOptionFunc) setOption(o *pipeReaderOptions) {
 	p(o)
 }
 

--- a/pipe.go
+++ b/pipe.go
@@ -2,103 +2,15 @@ package log
 
 import (
 	"io"
-	"sync"
 
 	"go.uber.org/zap/zapcore"
 )
 
-// pipes is the global instance of pipesSink
-var pipes = newPipesSink()
-
-// pipesSink is a Zap Sink that copies log output to zero or more
-// connected pipe readers. Pipe readers represent in-process readers
-// that are listening to the log output.
-type pipesSink struct {
-	mu       sync.RWMutex
-	combined zapcore.WriteSyncer
-	writers  map[*PipeReader]zapcore.WriteSyncer
-}
-
-func newPipesSink() *pipesSink {
-	s := &pipesSink{
-		writers: make(map[*PipeReader]zapcore.WriteSyncer),
-	}
-	// Initially this will result in a WriteSyncer that wraps io.Discard
-	s.buildCombinedWriter()
-	return s
-}
-
-func (s *pipesSink) Close() error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	// We can ignore errors since these in-memory pipes won't error on
-	// close and, besides, we are most likely closing the process.
-	for pr := range s.writers {
-		_ = pr.r.Close()
-	}
-
-	return nil
-}
-
-func (s *pipesSink) Sync() error {
-	s.mu.RLock()
-	err := s.combined.Sync()
-	s.mu.RUnlock()
-	return err
-}
-
-func (s *pipesSink) Write(b []byte) (int, error) {
-	s.mu.RLock()
-	n, err := s.combined.Write(b)
-	s.mu.RUnlock()
-	return n, err
-}
-
-// NewReader registers a new pipe reader and rebuilds the
-// combined Zap WriteSyncer to include it.
-func (s *pipesSink) NewReader() *PipeReader {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	r, w := io.Pipe()
-	pr := &PipeReader{
-		r:    r,
-		sink: s,
-	}
-
-	ws := zapcore.AddSync(w)
-	s.writers[pr] = ws
-
-	s.buildCombinedWriter()
-
-	return pr
-}
-
-// note the caller must hold s.mu before calling buildCombinedWriter
-func (s *pipesSink) buildCombinedWriter() {
-	current := make([]zapcore.WriteSyncer, 0, len(s.writers))
-	for _, ws := range s.writers {
-		current = append(current, ws)
-	}
-	s.combined = zapcore.NewMultiWriteSyncer(current...)
-}
-
-// RemoveReader unregisters a pipe reader and rebuilds the
-// combined Zap WriteSyncer to exclude it.
-func (s *pipesSink) RemoveReader(p *PipeReader) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	delete(s.writers, p)
-	s.buildCombinedWriter()
-}
-
 // A PipeReader is a reader that reads from the logger. It is synchronous
 // so blocking on read will affect logging performance.
 type PipeReader struct {
-	sink *pipesSink
 	r    *io.PipeReader
+	core zapcore.Core
 }
 
 // Read implements the standard Read interface
@@ -108,12 +20,63 @@ func (p *PipeReader) Read(data []byte) (int, error) {
 
 // Close unregisters the reader from the logger.
 func (p *PipeReader) Close() error {
-	p.sink.RemoveReader(p)
+	if p.core != nil {
+		loggerCore.DeleteCore(p.core)
+	}
 	return p.r.Close()
 }
 
-// NewPipeReader creates a new in-memory reader that reads from the logger.
+// NewPipeReader creates a new in-memory reader that reads from all loggers
 // The caller must call Close on the returned reader when done.
-func NewPipeReader() *PipeReader {
-	return pipes.NewReader()
+func NewPipeReader(opts ...PipeReaderOption) *PipeReader {
+	loggerMutex.Lock()
+	opt := pipeReaderOptions{
+		format: primaryFormat,
+		level:  primaryLevel,
+	}
+	loggerMutex.Unlock()
+
+	for _, o := range opts {
+		o.SetOption(&opt)
+	}
+
+	r, w := io.Pipe()
+
+	p := &PipeReader{
+		r:    r,
+		core: newCore(opt.format, zapcore.AddSync(w), opt.level),
+	}
+
+	loggerCore.AddCore(p.core)
+
+	return p
+}
+
+type pipeReaderOptions struct {
+	format LogFormat
+	level  LogLevel
+}
+
+type PipeReaderOption interface {
+	SetOption(*pipeReaderOptions)
+}
+
+type pipeReaderOptionFunc func(*pipeReaderOptions)
+
+func (p pipeReaderOptionFunc) SetOption(o *pipeReaderOptions) {
+	p(o)
+}
+
+// PipeFormat sets the output format of the pipe reader
+func PipeFormat(format LogFormat) PipeReaderOption {
+	return pipeReaderOptionFunc(func(o *pipeReaderOptions) {
+		o.format = format
+	})
+}
+
+// PipeLevel sets the log level of logs sent to the pipe reader.
+func PipeLevel(level LogLevel) PipeReaderOption {
+	return pipeReaderOptionFunc(func(o *pipeReaderOptions) {
+		o.level = level
+	})
 }

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -1,0 +1,97 @@
+package log
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestNewPipeReader(t *testing.T) {
+	log := getLogger("test")
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	r := NewPipeReader()
+
+	buf := &bytes.Buffer{}
+	go func() {
+		defer wg.Done()
+		io.Copy(buf, r)
+	}()
+
+	log.Error("scooby")
+	r.Close()
+	wg.Wait()
+
+	if !strings.Contains(buf.String(), "scooby") {
+		t.Errorf("got %q, wanted it to contain log output", buf.String())
+	}
+
+}
+
+func TestNewPipeReaderFormat(t *testing.T) {
+	log := getLogger("test")
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	r := NewPipeReader(PipeFormat(PlaintextOutput))
+
+	buf := &bytes.Buffer{}
+	go func() {
+		defer wg.Done()
+		io.Copy(buf, r)
+	}()
+
+	log.Error("scooby")
+	r.Close()
+	wg.Wait()
+
+	if !strings.Contains(buf.String(), "scooby") {
+		t.Errorf("got %q, wanted it to contain log output", buf.String())
+	}
+
+}
+
+func TestNewPipeReaderLevel(t *testing.T) {
+	SetupLogging(Config{
+		Level:  LevelDebug,
+		Format: PlaintextOutput,
+	})
+
+	log := getLogger("test")
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	r := NewPipeReader(PipeLevel(LevelError))
+
+	buf := &bytes.Buffer{}
+	go func() {
+		defer wg.Done()
+		io.Copy(buf, r)
+	}()
+
+	log.Debug("scooby")
+	log.Info("velma")
+	log.Error("shaggy")
+	r.Close()
+	wg.Wait()
+
+	lineEnding := zap.NewProductionEncoderConfig().LineEnding
+
+	// Should only contain one log line
+	if strings.Count(buf.String(), lineEnding) > 1 {
+		t.Errorf("got %d log lines, wanted 1", strings.Count(buf.String(), lineEnding))
+	}
+
+	if !strings.Contains(buf.String(), "shaggy") {
+		t.Errorf("got %q, wanted it to contain log output", buf.String())
+	}
+
+}

--- a/setup.go
+++ b/setup.go
@@ -3,7 +3,6 @@ package log
 import (
 	"errors"
 	"fmt"
-	"net/url"
 	"os"
 	"regexp"
 	"sync"
@@ -13,12 +12,7 @@ import (
 )
 
 func init() {
-	// register the global pipes sink to allow us to specify it as an output
-	zap.RegisterSink("pipes", func(*url.URL) (zap.Sink, error) {
-		return pipes, nil
-	})
-
-	SetupLogging()
+	SetupLogging(configFromEnv())
 }
 
 // Logging environment variables
@@ -37,70 +31,95 @@ const (
 	envLoggingFile = "GOLOG_FILE" // /path/to/file
 )
 
+type LogFormat int
+
+const (
+	ColorizedOutput LogFormat = iota
+	PlaintextOutput
+	JSONOutput
+)
+
+type Config struct {
+	// Format overrides the format of the log output. Defaults to ColorizedOutput
+	Format LogFormat
+
+	// Level is the minimum enabled logging level.
+	Level LogLevel
+
+	// Stderr indicates whether logs should be written to stderr.
+	Stderr bool
+
+	// Stdout indicates whether logs should be written to stdout.
+	Stdout bool
+
+	// File is a path to a file that logs will be written to.
+	File string
+}
+
 // ErrNoSuchLogger is returned when the util pkg is asked for a non existant logger
 var ErrNoSuchLogger = errors.New("Error: No such logger")
 
+var loggerMutex sync.RWMutex // guards access to global logger state
+
 // loggers is the set of loggers in the system
-var loggerMutex sync.RWMutex
 var loggers = make(map[string]*zap.SugaredLogger)
 var levels = make(map[string]zap.AtomicLevel)
+
+// primaryFormat is the default format of the primary core used for logging
+var primaryFormat LogFormat = ColorizedOutput
+
+// primaryLevel is the default log level of the primary core used for logging
+var primaryLevel LogLevel = LevelError
+
+// primaryCore is the primary logging core
+var primaryCore zapcore.Core
+
+// loggerCore is the base for all loggers created by this package
+var loggerCore = &lockedMultiCore{}
 
 // SetupLogging will initialize the logger backend and set the flags.
 // TODO calling this in `init` pushes all configuration to env variables
 // - move it out of `init`? then we need to change all the code (js-ipfs, go-ipfs) to call this explicitly
 // - have it look for a config file? need to define what that is
-var zapCfg = zap.NewProductionConfig()
+func SetupLogging(cfg Config) {
+	loggerMutex.Lock()
+	defer loggerMutex.Unlock()
 
-func SetupLogging() {
-	loggingFmt := os.Getenv(envLoggingFmt)
-	if loggingFmt == "" {
-		loggingFmt = os.Getenv(envIPFSLoggingFmt)
+	primaryFormat = cfg.Format
+	primaryLevel = cfg.Level
+
+	outputPaths := []string{}
+
+	if cfg.Stderr {
+		outputPaths = append(outputPaths, "stderr")
 	}
-	// colorful or plain
-	switch loggingFmt {
-	case "nocolor":
-		zapCfg.Encoding = "console"
-		zapCfg.EncoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
-	case "json":
-		zapCfg.Encoding = "json"
-	default:
-		zapCfg.Encoding = "console"
-		zapCfg.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
+	if cfg.Stdout {
+		outputPaths = append(outputPaths, "stdout")
 	}
 
-	zapCfg.Sampling = nil
-	zapCfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
-	zapCfg.DisableStacktrace = true
-
-	zapCfg.OutputPaths = []string{"stderr", "pipes://"}
 	// check if we log to a file
-	if logfp := os.Getenv(envLoggingFile); len(logfp) > 0 {
-		if path, err := normalizePath(logfp); err != nil {
-			fmt.Fprintf(os.Stderr, "failed to resolve log path '%q', logging to stderr only: %s\n", logfp, err)
+	if len(cfg.File) > 0 {
+		if path, err := normalizePath(cfg.File); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to resolve log path '%q', logging to %s\n", cfg.File, outputPaths)
 		} else {
-			// If file is specified, we will only log to the file
-			zapCfg.OutputPaths = []string{path}
+			outputPaths = append(outputPaths, path)
 		}
 	}
 
-	// set the backend(s)
-	lvl := LevelError
-
-	logenv := os.Getenv(envLogging)
-	if logenv == "" {
-		logenv = os.Getenv(envIPFSLogging)
+	ws, _, err := zap.Open(outputPaths...)
+	if err != nil {
+		panic(fmt.Sprintf("unable to open logging output: %v", err))
 	}
 
-	if logenv != "" {
-		var err error
-		lvl, err = LevelFromString(logenv)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "error setting log levels: %s\n", err)
-		}
+	newPrimaryCore := newCore(primaryFormat, ws, primaryLevel)
+	if primaryCore != nil {
+		loggerCore.ReplaceCore(primaryCore, newPrimaryCore)
+	} else {
+		loggerCore.AddCore(newPrimaryCore)
 	}
-	zapCfg.Level.SetLevel(zapcore.Level(lvl))
+	primaryCore = newPrimaryCore
 
-	SetAllLoggers(lvl)
+	setAllLoggers(primaryLevel)
 }
 
 // SetDebugLogging calls SetAllLoggers with logging.DEBUG
@@ -113,6 +132,10 @@ func SetAllLoggers(lvl LogLevel) {
 	loggerMutex.RLock()
 	defer loggerMutex.RUnlock()
 
+	setAllLoggers(lvl)
+}
+
+func setAllLoggers(lvl LogLevel) {
 	for _, l := range levels {
 		l.SetLevel(zapcore.Level(lvl))
 	}
@@ -186,16 +209,56 @@ func getLogger(name string) *zap.SugaredLogger {
 	defer loggerMutex.Unlock()
 	log, ok := loggers[name]
 	if !ok {
-		levels[name] = zap.NewAtomicLevelAt(zapCfg.Level.Level())
-		cfg := zap.Config(zapCfg)
-		cfg.Level = levels[name]
-		newlog, err := cfg.Build()
-		if err != nil {
-			panic(err)
-		}
-		log = newlog.Named(name).Sugar()
+		levels[name] = zap.NewAtomicLevelAt(zapcore.Level(primaryLevel))
+		log = zap.New(loggerCore).
+			WithOptions(zap.IncreaseLevel(levels[name])).
+			Named(name).
+			Sugar()
+
 		loggers[name] = log
 	}
 
 	return log
+}
+
+// configFromEnv returns a Config with defaults populated using environment variables.
+func configFromEnv() Config {
+	cfg := Config{
+		Format: ColorizedOutput,
+		Stderr: true,
+		Level:  LevelError,
+	}
+
+	format := os.Getenv(envLoggingFmt)
+	if format == "" {
+		format = os.Getenv(envIPFSLoggingFmt)
+	}
+
+	switch format {
+	case "nocolor":
+		cfg.Format = PlaintextOutput
+	case "json":
+		cfg.Format = JSONOutput
+	}
+
+	lvl := os.Getenv(envLogging)
+	if lvl == "" {
+		lvl = os.Getenv(envIPFSLogging)
+	}
+	if lvl != "" {
+		var err error
+		cfg.Level, err = LevelFromString(lvl)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error setting log levels: %s\n", err)
+		}
+	}
+
+	cfg.File = os.Getenv(envLoggingFile)
+	// Disable stderr logging when a file is specified
+	// https://github.com/ipfs/go-log/issues/83
+	if cfg.File != "" {
+		cfg.Stderr = false
+	}
+
+	return cfg
 }

--- a/setup_test.go
+++ b/setup_test.go
@@ -1,0 +1,37 @@
+package log
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestGetLoggerDefault(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to open pipe: %v", err)
+	}
+
+	stderr := os.Stderr
+	os.Stderr = w
+	defer func() {
+		os.Stderr = stderr
+	}()
+
+	// Call SetupLogging again so it picks up stderr change
+	SetupLogging(Config{Stderr: true})
+	log := getLogger("test")
+
+	log.Error("scooby")
+	w.Close()
+
+	buf := &bytes.Buffer{}
+	io.Copy(buf, r)
+
+	if !strings.Contains(buf.String(), "scooby") {
+		t.Errorf("got %q, wanted it to contain log output", buf.String())
+	}
+
+}


### PR DESCRIPTION
Another take on https://github.com/ipfs/go-log/issues/66

This change introduces a multicore implementation that allows
additonal zap cores to be added at runtime. Each core can be
configured with distinct encoders and writers which makes
it possible to tail the logs in a program using a different
log format (e.g. program may log in json but interactive
tailing can be in plaintext). This comes at the cost of an
additional mutex that must be taken on each write since the
destination of the write is mutable.

It reworks (and simplifies) the pipe reader implementation
added in https://github.com/ipfs/go-log/pull/87 and adds a
new function NewPipeReaderFormat which creates a pipe reader
using a different output format.

This change also allows us to reconfigure logging after it has been
initialised by swapping out the initial zap core with a
newly configured one. This solves the problem that I attempted
in https://github.com/ipfs/go-log/pull/88

Adds a Config struct to enable easier reconfiguration
of the logger. The default config is still read from the
environment in init() but a client of the package can now call
SetupLogging again with a custom config to adjust logging after
initialization.

Note that the fix for https://github.com/ipfs/go-log/issues/83
is slightly different. If a file is specified using GOLOG_FILE
then logging to stderr will be disabled but logging can be
configured to write to both file and stderr by calling SetupLogging
with the appropriate configuration.