### PR TITLE
Fix log level handling

### DIFF
--- a/log_level_test.go
+++ b/log_level_test.go
@@ -1,0 +1,43 @@
+package log
+
+import (
+	"encoding/json"
+	"io"
+	"testing"
+)
+
+func TestLogLevel(t *testing.T) {
+	const subsystem = "log-level-test"
+	logger := Logger(subsystem)
+	reader := NewPipeReader()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		decoder := json.NewDecoder(reader)
+		for {
+			var entry struct {
+				Message string `json:"msg"`
+			}
+			err := decoder.Decode(&entry)
+			switch err {
+			default:
+				t.Error(err)
+				return
+			case io.EOF:
+				return
+			case nil:
+			}
+			if entry.Message != "bar" {
+				t.Errorf("unexpected message: %s", entry.Message)
+			}
+		}
+	}()
+	logger.Debugw("foo")
+	SetLogLevel(subsystem, "debug")
+	logger.Debugw("bar")
+	SetAllLoggers(LevelInfo)
+	logger.Debugw("baz")
+	logger.Sync()
+	reader.Close()
+	<-done
+}

--- a/pipe.go
+++ b/pipe.go
@@ -33,10 +33,10 @@ func (p *PipeReader) Close() error {
 //
 // By default, it:
 //
-// 1. Logs JSON.
-// 2. Logs at the Debug level. However, unless SetLogLevel is called on a
-//    subsystem logger to decrease the default log level, for that subsystem,
-//    only error messages will be logged.
+// 1. Logs JSON. This can be changed by passing the PipeFormat option.
+// 2. Logs everything that would otherwise be logged to the "primary" log
+//    output. That is, everything enabled by SetLogLevel. The minimum log level
+//    can be increased by passing the PipeLevel option.
 func NewPipeReader(opts ...PipeReaderOption) *PipeReader {
 	opt := pipeReaderOptions{
 		format: JSONOutput,

--- a/pipe.go
+++ b/pipe.go
@@ -3,6 +3,7 @@ package log
 import (
 	"io"
 
+	"go.uber.org/multierr"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -24,7 +25,7 @@ func (p *PipeReader) Close() error {
 	if p.core != nil {
 		loggerCore.DeleteCore(p.core)
 	}
-	return p.closer.Close()
+	return multierr.Append(p.core.Sync(), p.closer.Close())
 }
 
 // NewPipeReader creates a new in-memory reader that reads from all loggers

--- a/pipe.go
+++ b/pipe.go
@@ -31,8 +31,8 @@ func (p *PipeReader) Close() error {
 func NewPipeReader(opts ...PipeReaderOption) *PipeReader {
 	loggerMutex.Lock()
 	opt := pipeReaderOptions{
-		format: primaryFormat,
-		level:  primaryLevel,
+		format: defaultFormat,
+		level:  LevelDebug,
 	}
 	loggerMutex.Unlock()
 

--- a/pipe.go
+++ b/pipe.go
@@ -28,13 +28,18 @@ func (p *PipeReader) Close() error {
 
 // NewPipeReader creates a new in-memory reader that reads from all loggers
 // The caller must call Close on the returned reader when done.
+//
+// By default, it:
+//
+// 1. Logs JSON.
+// 2. Logs at the Debug level. However, unless SetLogLevel is called on a
+//    subsystem logger to decrease the default log level, for that subsystem,
+//    only error messages will be logged.
 func NewPipeReader(opts ...PipeReaderOption) *PipeReader {
-	loggerMutex.Lock()
 	opt := pipeReaderOptions{
-		format: defaultFormat,
+		format: JSONOutput,
 		level:  LevelDebug,
 	}
-	loggerMutex.Unlock()
 
 	for _, o := range opts {
 		o.setOption(&opt)

--- a/setup.go
+++ b/setup.go
@@ -65,8 +65,8 @@ var loggerMutex sync.RWMutex // guards access to global logger state
 var loggers = make(map[string]*zap.SugaredLogger)
 var levels = make(map[string]zap.AtomicLevel)
 
-// defaultFormat is the default format of the primary core used for logging
-var defaultFormat LogFormat = ColorizedOutput
+// primaryFormat is the format of the primary core used for logging
+var primaryFormat LogFormat = ColorizedOutput
 
 // defaultLevel is the default log level
 var defaultLevel LogLevel = LevelError
@@ -85,7 +85,7 @@ func SetupLogging(cfg Config) {
 	loggerMutex.Lock()
 	defer loggerMutex.Unlock()
 
-	defaultFormat = cfg.Format
+	primaryFormat = cfg.Format
 	defaultLevel = cfg.Level
 
 	outputPaths := []string{}
@@ -111,7 +111,7 @@ func SetupLogging(cfg Config) {
 		panic(fmt.Sprintf("unable to open logging output: %v", err))
 	}
 
-	newPrimaryCore := newCore(defaultFormat, ws, LevelDebug) // the main core needs to log everything.
+	newPrimaryCore := newCore(primaryFormat, ws, LevelDebug) // the main core needs to log everything.
 	if primaryCore != nil {
 		loggerCore.ReplaceCore(primaryCore, newPrimaryCore)
 	} else {


### PR DESCRIPTION
Currently, we filter messages at two layers:

1. At individual subsystem loggers.
2. At the final logging core.

However, the final log level was set to ERROR. That meant that reducing the level on subsystem loggers didn't actually do anything. This meant `SetLogLevel` didn't work. This change sets the default log level for pipe readers and the default logging core to DEBUG.

This change also changes the default pipe reader format to JSON to avoid taking a lock. IMO, this should be less surprising regardless as it's more predictable.

I'm not entirely happy about how we're handing log levels but this should be good enough for now. Ideally, we'd have https://github.com/ipfs/go-log/issues/92.