### PR TITLE
enable configuring several log outputs

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 	"sync"
 
 	"go.uber.org/zap"
@@ -265,48 +266,20 @@ func configFromEnv() Config {
 	}
 
 	output := os.Getenv(envLoggingOutput)
+	outputOptions := strings.Split(output, "+")
 	//TODO: fix lanzafame's super lazy impl...
-	switch output {
-	case "stdout":
-		cfg.Stdout = true
-		cfg.Stderr = false
-		cfg.File = ""
-	case "stderr":
-		cfg.Stderr = true
-		cfg.Stdout = false
-		cfg.File = ""
-	case "file":
-		cfg.File = os.Getenv(envLoggingFile)
-		if cfg.File != "" {
-			fmt.Fprint(os.Stderr, "please specify a GOLOG_FILE value to write to")
+	for _, opt := range outputOptions {
+		switch opt {
+		case "stdout":
+			cfg.Stdout = true
+		case "stderr":
+			cfg.Stderr = true
+		case "file":
+			cfg.File = os.Getenv(envLoggingFile)
+			if cfg.File != "" {
+				fmt.Fprint(os.Stderr, "please specify a GOLOG_FILE value to write to")
+			}
 		}
-		cfg.Stderr = false
-		cfg.Stdout = false
-	case "stdout+file", "file+stdout":
-		cfg.File = os.Getenv(envLoggingFile)
-		if cfg.File != "" {
-			fmt.Fprint(os.Stderr, "please specify a GOLOG_FILE value to write to")
-		}
-		cfg.Stderr = false
-		cfg.Stdout = true
-	case "stderr+file", "file+stderr":
-		cfg.File = os.Getenv(envLoggingFile)
-		if cfg.File != "" {
-			fmt.Fprint(os.Stderr, "please specify a GOLOG_FILE value to write to")
-		}
-		cfg.Stderr = true
-		cfg.Stdout = false
-	case "stdout+stderr", "stderr+stdout":
-		cfg.File = ""
-		cfg.Stderr = true
-		cfg.Stdout = true
-	case "stdout+stderr+file", "stdout+file+stderr", "stderr+stdout+file", "stderr+file+stdout", "file+stdout+stderr", "file+stderr+stdout":
-		cfg.File = os.Getenv(envLoggingFile)
-		if cfg.File != "" {
-			fmt.Fprint(os.Stderr, "please specify a GOLOG_FILE value to write to")
-		}
-		cfg.Stderr = true
-		cfg.Stdout = true
 	}
 
 	return cfg

--- a/setup.go
+++ b/setup.go
@@ -267,7 +267,6 @@ func configFromEnv() Config {
 
 	output := os.Getenv(envLoggingOutput)
 	outputOptions := strings.Split(output, "+")
-	//TODO: fix lanzafame's super lazy impl...
 	for _, opt := range outputOptions {
 		switch opt {
 		case "stdout":

--- a/setup.go
+++ b/setup.go
@@ -274,7 +274,6 @@ func configFromEnv() Config {
 		case "stderr":
 			cfg.Stderr = true
 		case "file":
-			cfg.File = os.Getenv(envLoggingFile)
 			if cfg.File != "" {
 				fmt.Fprint(os.Stderr, "please specify a GOLOG_FILE value to write to")
 			}

--- a/setup.go
+++ b/setup.go
@@ -274,7 +274,7 @@ func configFromEnv() Config {
 		case "stderr":
 			cfg.Stderr = true
 		case "file":
-			if cfg.File != "" {
+			if cfg.File == "" {
 				fmt.Fprint(os.Stderr, "please specify a GOLOG_FILE value to write to")
 			}
 		}

--- a/setup.go
+++ b/setup.go
@@ -29,6 +29,7 @@ const (
 	envLoggingFmt = "GOLOG_LOG_FMT"
 
 	envLoggingFile = "GOLOG_FILE" // /path/to/file
+	envLoggingOutput = "GOLOG_OUTPUT" // possible values: stdout|stderr|file combine multiple values with '+'
 )
 
 type LogFormat int
@@ -261,6 +262,51 @@ func configFromEnv() Config {
 	// https://github.com/ipfs/go-log/issues/83
 	if cfg.File != "" {
 		cfg.Stderr = false
+	}
+
+	output := os.Getenv(envLoggingOutput)
+	//TODO: fix lanzafame's super lazy impl...
+	switch output {
+	case "stdout":
+		cfg.Stdout = true
+		cfg.Stderr = false
+		cfg.File = ""
+	case "stderr":
+		cfg.Stderr = true
+		cfg.Stdout = false
+		cfg.File = ""
+	case "file":
+		cfg.File = os.Getenv(envLoggingFile)
+		if cfg.File != "" {
+			fmt.Fprint(os.Stderr, "please specify a GOLOG_FILE value to write to")
+		}
+		cfg.Stderr = false
+		cfg.Stdout = false
+	case "stdout+file", "file+stdout":
+		cfg.File = os.Getenv(envLoggingFile)
+		if cfg.File != "" {
+			fmt.Fprint(os.Stderr, "please specify a GOLOG_FILE value to write to")
+		}
+		cfg.Stderr = false
+		cfg.Stdout = true
+	case "stderr+file", "file+stderr":
+		cfg.File = os.Getenv(envLoggingFile)
+		if cfg.File != "" {
+			fmt.Fprint(os.Stderr, "please specify a GOLOG_FILE value to write to")
+		}
+		cfg.Stderr = true
+		cfg.Stdout = false
+	case "stdout+stderr", "stderr+stdout":
+		cfg.File = ""
+		cfg.Stderr = true
+		cfg.Stdout = true
+	case "stdout+stderr+file", "stdout+file+stderr", "stderr+stdout+file", "stderr+file+stdout", "file+stdout+stderr", "file+stderr+stdout":
+		cfg.File = os.Getenv(envLoggingFile)
+		if cfg.File != "" {
+			fmt.Fprint(os.Stderr, "please specify a GOLOG_FILE value to write to")
+		}
+		cfg.Stderr = true
+		cfg.Stdout = true
 	}
 
 	return cfg

--- a/setup_test.go
+++ b/setup_test.go
@@ -3,6 +3,7 @@ package log
 import (
 	"bytes"
 	"io"
+	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -36,4 +37,88 @@ func TestGetLoggerDefault(t *testing.T) {
 		t.Errorf("got %q, wanted it to contain log output", buf.String())
 	}
 
+}
+
+func TestLogToFileAndStderr(t *testing.T) {
+	// setup stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to open pipe: %v", err)
+	}
+
+	stderr := os.Stderr
+	os.Stderr = w
+	defer func() {
+		os.Stderr = stderr
+	}()
+
+	// setup file
+	logfile, err := ioutil.TempFile("", "go-log-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(logfile.Name())
+
+	os.Setenv(envLoggingFile, logfile.Name())
+
+	// set log output env var
+	os.Setenv(envLoggingOutput, "file+stderr")
+
+	SetupLogging(configFromEnv())
+
+	log := getLogger("test")
+
+	want := "scooby"
+	log.Error(want)
+	w.Close()
+
+	buf := &bytes.Buffer{}
+	if _, err := io.Copy(buf, r); err != nil && err != io.ErrClosedPipe {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(buf.String(), want) {
+		t.Errorf("got %q, wanted it to contain log output", buf.String())
+	}
+
+	content, err := ioutil.ReadFile(logfile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(content), want) {
+		t.Logf("want: '%s', got: '%s'", want, string(content))
+		t.Fail()
+	}
+}
+
+func TestLogToFile(t *testing.T) {
+	// get tmp log file
+	logfile, err := ioutil.TempFile("", "go-log-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(logfile.Name())
+
+	// set the go-log file env var
+	os.Setenv(envLoggingFile, logfile.Name())
+
+	SetupLogging(configFromEnv())
+
+	log := getLogger("test")
+
+	// write log to file
+	want := "grokgrokgrok"
+	log.Error(want)
+
+	// read log file and check contents
+	content, err := ioutil.ReadFile(logfile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(content), want) {
+		t.Logf("want: '%s', got: '%s'", want, string(content))
+		t.Fail()
+	}
 }


### PR DESCRIPTION
This PR introduces a new environment variable that allows a user to enable several log outputs for a logger. The env var is `GOLOG_OUTPUT` and takes a string of outputs concatenated by `+` similar to how the `StandardOutput` directive works in systems. An example value would be `file+stderr` which if `GOLOG_FILE` was set, would log to both the file and stderr.