### PR TITLE
per-subsystem log-levels

### DIFF
--- a/setup_test.go
+++ b/setup_test.go
@@ -158,3 +158,48 @@ func TestLogLabels(t *testing.T) {
 		t.Errorf("got %q, wanted it to contain log output", buf.String())
 	}
 }
+
+func TestSubsystemLevels(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to open pipe: %v", err)
+	}
+
+	stderr := os.Stderr
+	os.Stderr = w
+	defer func() {
+		os.Stderr = stderr
+	}()
+
+	// set the go-log labels env var
+	os.Setenv(envLogging, "info,test1=debug")
+	defer os.Unsetenv(envLoggingLabels)
+	SetupLogging(configFromEnv())
+
+	log1 := getLogger("test1")
+	log2 := getLogger("test2")
+
+	log1.Debug("debug1")
+	log1.Info("info1")
+	log2.Debug("debug2")
+	log2.Info("info2")
+	w.Close()
+
+	buf := &bytes.Buffer{}
+	if _, err := io.Copy(buf, r); err != nil && err != io.ErrClosedPipe {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "debug1") {
+		t.Errorf("got %q, wanted it to contain debug1", buf.String())
+	}
+	if strings.Contains(buf.String(), "debug2") {
+		t.Errorf("got %q, wanted it to not contain debug2", buf.String())
+	}
+	if !strings.Contains(buf.String(), "info1") {
+		t.Errorf("got %q, wanted it to contain info1", buf.String())
+	}
+	if !strings.Contains(buf.String(), "info2") {
+		t.Errorf("got %q, wanted it to contain info2", buf.String())
+	}
+}

--- a/setup_test.go
+++ b/setup_test.go
@@ -60,9 +60,11 @@ func TestLogToFileAndStderr(t *testing.T) {
 	defer os.Remove(logfile.Name())
 
 	os.Setenv(envLoggingFile, logfile.Name())
+	defer os.Unsetenv(envLoggingFile)
 
 	// set log output env var
 	os.Setenv(envLoggingOutput, "file+stderr")
+	defer os.Unsetenv(envLoggingOutput)
 
 	SetupLogging(configFromEnv())
 
@@ -102,6 +104,7 @@ func TestLogToFile(t *testing.T) {
 
 	// set the go-log file env var
 	os.Setenv(envLoggingFile, logfile.Name())
+	defer os.Unsetenv(envLoggingFile)
 
 	SetupLogging(configFromEnv())
 
@@ -137,6 +140,7 @@ func TestLogLabels(t *testing.T) {
 
 	// set the go-log labels env var
 	os.Setenv(envLoggingLabels, "app=example_app,dc=sjc-1,foobar") // foobar to ensure we don't panic on bad input.
+	defer os.Unsetenv(envLoggingLabels)
 	SetupLogging(configFromEnv())
 
 	log := getLogger("test")


### PR DESCRIPTION
Ex:

    GOLOG_LOG_LEVEL=error,foo=info,bar=debug

This will set the default log-level to error, foo's log-level o info, and bar's log-level to debug.

fixes #100