### PR TITLE
feat: add ability to use custom zap core

### DIFF
--- a/setup_test.go
+++ b/setup_test.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-
-	"go.uber.org/zap"
 )
 
 func TestGetLoggerDefault(t *testing.T) {
@@ -206,35 +204,39 @@ func TestSubsystemLevels(t *testing.T) {
 }
 
 func TestCustomCore(t *testing.T) {
-	r, w, err := os.Pipe()
+	r1, w1, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to open pipe: %v", err)
+	}
+	r2, w2, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("failed to open pipe: %v", err)
 	}
 
-	stderr := os.Stderr
-	os.Stderr = w
-	defer func() {
-		os.Stderr = stderr
-	}()
-
-	ws, _, err := zap.Open("stdout", "stderr")
-	if err != nil {
-		t.Fatalf("unable to open logging output: %v", err)
-	}
-
 	// logging should work with the custom core
-	SetPrimaryCore(newCore(PlaintextOutput, ws, LevelDebug))
+	SetPrimaryCore(newCore(PlaintextOutput, w1, LevelDebug))
 	log := getLogger("test")
-
 	log.Error("scooby")
-	w.Close()
 
-	buf := &bytes.Buffer{}
-	if _, err := io.Copy(buf, r); err != nil && err != io.ErrClosedPipe {
+	// SetPrimaryCore should replace the core in previously created loggers
+	SetPrimaryCore(newCore(PlaintextOutput, w2, LevelDebug))
+	log.Error("doo")
+
+	w1.Close()
+	w2.Close()
+
+	buf1 := &bytes.Buffer{}
+	buf2 := &bytes.Buffer{}
+	if _, err := io.Copy(buf1, r1); err != nil && err != io.ErrClosedPipe {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
-	if !strings.Contains(buf.String(), "scooby") {
-		t.Errorf("got %q, wanted it to contain log output", buf.String())
+	if _, err := io.Copy(buf2, r2); err != nil && err != io.ErrClosedPipe {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf1.String(), "scooby") {
+		t.Errorf("got %q, wanted it to contain log output", buf1.String())
+	}
+	if !strings.Contains(buf2.String(), "doo") {
+		t.Errorf("got %q, wanted it to contain log output", buf2.String())
 	}
 }

--- a/setup_test.go
+++ b/setup_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"go.uber.org/zap"
 )
 
 func TestGetLoggerDefault(t *testing.T) {
@@ -36,7 +38,6 @@ func TestGetLoggerDefault(t *testing.T) {
 	if !strings.Contains(buf.String(), "scooby") {
 		t.Errorf("got %q, wanted it to contain log output", buf.String())
 	}
-
 }
 
 func TestLogToFileAndStderr(t *testing.T) {
@@ -201,5 +202,39 @@ func TestSubsystemLevels(t *testing.T) {
 	}
 	if !strings.Contains(buf.String(), "info2") {
 		t.Errorf("got %q, wanted it to contain info2", buf.String())
+	}
+}
+
+func TestCustomCore(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to open pipe: %v", err)
+	}
+
+	stderr := os.Stderr
+	os.Stderr = w
+	defer func() {
+		os.Stderr = stderr
+	}()
+
+	ws, _, err := zap.Open("stdout", "stderr")
+	if err != nil {
+		t.Fatalf("unable to open logging output: %v", err)
+	}
+
+	// logging should work with the custom core
+	SetPrimaryCore(newCore(PlaintextOutput, ws, LevelDebug))
+	log := getLogger("test")
+
+	log.Error("scooby")
+	w.Close()
+
+	buf := &bytes.Buffer{}
+	if _, err := io.Copy(buf, r); err != nil && err != io.ErrClosedPipe {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "scooby") {
+		t.Errorf("got %q, wanted it to contain log output", buf.String())
 	}
 }


### PR DESCRIPTION
This PR adds the ability to replace the zap core with a custom one. It should solve the issue: https://github.com/ipfs/go-log/issues/102. 

I explained my reasoning for adding the `SetPrimaryCore` function in this comment: https://github.com/ipfs/go-log/issues/102#issuecomment-850930348.