### PR TITLE
fix: cannot call SetPrimaryCore after using a Tee logger

### DIFF
--- a/core.go
+++ b/core.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"reflect"
 	"sync"
 
 	"go.uber.org/multierr"
@@ -80,7 +81,7 @@ func (l *lockedMultiCore) DeleteCore(core zapcore.Core) {
 
 	w := 0
 	for i := 0; i < len(l.cores); i++ {
-		if l.cores[i] == core {
+		if reflect.DeepEqual(l.cores[i], core) {
 			continue
 		}
 		l.cores[w] = l.cores[i]
@@ -94,7 +95,7 @@ func (l *lockedMultiCore) ReplaceCore(original, replacement zapcore.Core) {
 	defer l.mu.Unlock()
 
 	for i := 0; i < len(l.cores); i++ {
-		if l.cores[i] == original {
+		if reflect.DeepEqual(l.cores[i], original) {
 			l.cores[i] = replacement
 		}
 	}

--- a/setup_test.go
+++ b/setup_test.go
@@ -7,6 +7,9 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 func TestGetLoggerDefault(t *testing.T) {
@@ -239,4 +242,19 @@ func TestCustomCore(t *testing.T) {
 	if !strings.Contains(buf2.String(), "doo") {
 		t.Errorf("got %q, wanted it to contain log output", buf2.String())
 	}
+}
+
+func TestTeeCore(t *testing.T) {
+	// configure to use a tee logger
+	tee := zap.New(zapcore.NewTee(
+		zap.NewNop().Core(),
+		zap.NewNop().Core(),
+	), zap.AddCaller())
+	SetPrimaryCore(tee.Core())
+	log := getLogger("test")
+	log.Error("scooby")
+
+	// replaces the tee logger with a simple one
+	SetPrimaryCore(zap.NewNop().Core())
+	log.Error("doo")
 }


### PR DESCRIPTION
# Previous behavior

Calling `SetPrimaryCore` after being configured with a [`zapcore.Tee`](https://pkg.go.dev/go.uber.org/zap/zapcore#NewTee) causes a `panic: runtime error: comparing uncomparable type zapcore.multiCore`

```console
$ go test -v ./... -count 1 -run TestTeeCore
=== RUN   TestTeeCore
failed to IncreaseLevel: invalid increase level, as level "fatal" is allowed by increased level, but not by existing core
--- FAIL: TestTeeCore (0.00s)
panic: runtime error: comparing uncomparable type zapcore.multiCore [recovered]
        panic: runtime error: comparing uncomparable type zapcore.multiCore

goroutine 19 [running]:
testing.tRunner.func1.2(0x612ea0, 0xc000099060)
        /nix/store/mjpyjqs53d77c691c46kdd97a4094pjm-go-1.16.7/share/go/src/testing/testing.go:1143 +0x332
testing.tRunner.func1(0xc000082900)
        /nix/store/mjpyjqs53d77c691c46kdd97a4094pjm-go-1.16.7/share/go/src/testing/testing.go:1146 +0x4b6
panic(0x612ea0, 0xc000099060)
        /nix/store/mjpyjqs53d77c691c46kdd97a4094pjm-go-1.16.7/share/go/src/runtime/panic.go:965 +0x1b9
github.com/ipfs/go-log/v2.(*lockedMultiCore).ReplaceCore(0x7d7600, 0x699640, 0xc0000ba138, 0x699680, 0x805650)
        /home/moul/go/src/github.com/ipfs/go-log/core.go:97 +0xab
github.com/ipfs/go-log/v2.setPrimaryCore(0x699680, 0x805650)
        /home/moul/go/src/github.com/ipfs/go-log/setup.go:161 +0x65
github.com/ipfs/go-log/v2.SetPrimaryCore(0x699680, 0x805650)
        /home/moul/go/src/github.com/ipfs/go-log/setup.go:156 +0x73
github.com/ipfs/go-log/v2.TestTeeCore(0xc000082900)
        /home/moul/go/src/github.com/ipfs/go-log/setup_test.go:258 +0x2b1
testing.tRunner(0xc000082900, 0x662380)
        /nix/store/mjpyjqs53d77c691c46kdd97a4094pjm-go-1.16.7/share/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
        /nix/store/mjpyjqs53d77c691c46kdd97a4094pjm-go-1.16.7/share/go/src/testing/testing.go:1238 +0x2b3
FAIL    github.com/ipfs/go-log/v2       0.008s
FAIL
```

# New behavior

No panic

h/t @gfanton