### PR TITLE
Config inspection

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -13,6 +13,8 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+var config Config
+
 func init() {
 	SetupLogging(configFromEnv())
 }
@@ -92,6 +94,12 @@ var primaryCore zapcore.Core
 // loggerCore is the base for all loggers created by this package
 var loggerCore = &lockedMultiCore{}
 
+// GetConfig returns a copy of the saved config. It can be inspected, modified,
+// and re-applied using a subsequent call to SetupLogging().
+func GetConfig() Config {
+	return config
+}
+
 // SetupLogging will initialize the logger backend and set the flags.
 // TODO calling this in `init` pushes all configuration to env variables
 // - move it out of `init`? then we need to change all the code (js-ipfs, go-ipfs) to call this explicitly
@@ -99,6 +107,8 @@ var loggerCore = &lockedMultiCore{}
 func SetupLogging(cfg Config) {
 	loggerMutex.Lock()
 	defer loggerMutex.Unlock()
+
+	config = cfg
 
 	primaryFormat = cfg.Format
 	defaultLevel = cfg.Level


### PR DESCRIPTION
This ended up being a totally microscopic change, but it'll be extremely useful to library users. It is non-breaking change.

This saves the config into a private global variable upon applying it. You can call `GetConfig()` to read a _copy_ of the config, and then it can be modified and re-applied using `SetupLogging()`.

More info at #122. This solution is probably nicer than exposing `configFromEnv()`, because it reflects the _actual_ current state of the logger, which could potentially change before `configFromEnv()` is next called.