### PR TITLE
add env config to set core with FullCallerEncoder

### DIFF
--- a/core.go
+++ b/core.go
@@ -104,7 +104,25 @@ func (l *lockedMultiCore) ReplaceCore(original, replacement zapcore.Core) {
 func newCore(format LogFormat, ws zapcore.WriteSyncer, level LogLevel) zapcore.Core {
 	encCfg := zap.NewProductionEncoderConfig()
 	encCfg.EncodeTime = zapcore.ISO8601TimeEncoder
+	var encoder zapcore.Encoder
+	switch format {
+	case PlaintextOutput:
+		encCfg.EncodeLevel = zapcore.CapitalLevelEncoder
+		encoder = zapcore.NewConsoleEncoder(encCfg)
+	case JSONOutput:
+		encoder = zapcore.NewJSONEncoder(encCfg)
+	default:
+		encCfg.EncodeLevel = zapcore.CapitalColorLevelEncoder
+		encoder = zapcore.NewConsoleEncoder(encCfg)
+	}
 
+	return zapcore.NewCore(encoder, ws, zap.NewAtomicLevelAt(zapcore.Level(level)))
+}
+
+func newCoreWithFullCallerEncCfg(format LogFormat, ws zapcore.WriteSyncer, level LogLevel) zapcore.Core {
+	encCfg := zap.NewProductionEncoderConfig()
+	encCfg.EncodeTime = zapcore.ISO8601TimeEncoder
+	encCfg.EncodeCaller = zapcore.FullCallerEncoder
 	var encoder zapcore.Encoder
 	switch format {
 	case PlaintextOutput:

--- a/setup.go
+++ b/setup.go
@@ -37,6 +37,9 @@ const (
 
 	envLoggingOutput = "GOLOG_OUTPUT"     // possible values: stdout|stderr|file combine multiple values with '+'
 	envLoggingLabels = "GOLOG_LOG_LABELS" // comma-separated key-value pairs, i.e. "app=example_app,dc=sjc-1"
+	// full: /full/path/to/package/file:line format.
+	// short: package/file:line format, trimming all but the final directory from the full path.
+	envLoggingCallerFormat = "GOLOG_LOG_CALLER_FORMAT" // possible values: full|short
 )
 
 type LogFormat int
@@ -71,6 +74,9 @@ type Config struct {
 
 	// Labels is a set of key-values to apply to all loggers
 	Labels map[string]string
+
+	// Format for Caller line. possible values: full|short. default short.
+	CallerFormat string
 }
 
 // ErrNoSuchLogger is returned when the util pkg is asked for a non existant logger
@@ -138,8 +144,12 @@ func SetupLogging(cfg Config) {
 	if err != nil {
 		panic(fmt.Sprintf("unable to open logging output: %v", err))
 	}
-
-	newPrimaryCore := newCore(primaryFormat, ws, LevelDebug) // the main core needs to log everything.
+	var newPrimaryCore zapcore.Core
+	if cfg.CallerFormat == "short" {
+		newPrimaryCore = newCore(primaryFormat, ws, LevelDebug) // the main core needs to log everything.
+	} else {
+		newPrimaryCore = newCoreWithFullCallerEncCfg(primaryFormat, ws, LevelDebug) // the main core needs to log everything.
+	}
 
 	for k, v := range cfg.Labels {
 		newPrimaryCore = newPrimaryCore.With([]zap.Field{zap.String(k, v)})
@@ -381,6 +391,13 @@ func configFromEnv() Config {
 			}
 			cfg.Labels[kv[0]] = kv[1]
 		}
+	}
+
+	CallerFormat := os.Getenv(envLoggingCallerFormat)
+	if CallerFormat == "full" {
+		cfg.CallerFormat = "full"
+	} else {
+		cfg.CallerFormat = "short"
 	}
 
 	return cfg


### PR DESCRIPTION
Sometimes we need to view the full file path, so i add an environment configuration item to configure
``` go
// full: /full/path/to/package/file:line format.
// short: package/file:line format, trimming all but the final directory from the full path.
envLoggingCallerFormat = "GOLOG_LOG_CALLER_FORMAT" // possible values: full|short
```