### PR TITLE
Revise the loglevel API to be more golang idiomatic

### DIFF
--- a/levels.go
+++ b/levels.go
@@ -6,6 +6,14 @@ import "go.uber.org/zap/zapcore"
 // enum.
 type LogLevel zapcore.Level
 
+// DefaultName is the subsystem name that identifies the default log level.
+const DefaultName = ""
+
+// String returns the name of a LogLevel.
+func (lvl LogLevel) String() string {
+	return zapcore.Level(lvl).String()
+}
+
 var (
 	LevelDebug  = LogLevel(zapcore.DebugLevel)
 	LevelInfo   = LogLevel(zapcore.InfoLevel)
@@ -16,51 +24,43 @@ var (
 	LevelFatal  = LogLevel(zapcore.FatalLevel)
 )
 
-// LevelFromString parses a string-based level and returns the corresponding
-// LogLevel.
-//
-// Supported strings are: DEBUG, INFO, WARN, ERROR, DPANIC, PANIC, FATAL, and
-// their lower-case forms.
-//
-// The returned LogLevel must be discarded if error is not nil.
-func LevelFromString(level string) (LogLevel, error) {
-	lvl := zapcore.InfoLevel // zero value
-	err := lvl.Set(level)
+// Parse parses a string-based level and returns the corresponding LogLevel. An
+// error is returned of the string is not the name of a supported LogLevel.
+func Parse(name string) (LogLevel, error) {
+	var lvl zapcore.Level
+	err := lvl.Set(name)
 	return LogLevel(lvl), err
 }
 
-// LevelName returns the name of a LogLevel.
-func LevelName(level LogLevel) string {
-	return zapcore.Level(level).String()
+// DefaultLevel returns the current default LogLevel.
+func DefaultLevel() LogLevel {
+	loggerMutex.RLock()
+	lvl := defaultLevel
+	loggerMutex.RUnlock()
+	return lvl
 }
 
-// GetLogLevel returns the current log level for a given subsystem as a string.
-// Passing name="*" or name="" returns the defaultLevel.
-func GetLogLevel(name string) (string, error) {
-	if name == "*" || name == "" {
-		loggerMutex.RLock()
-		defLvl := defaultLevel
-		loggerMutex.RUnlock()
-		return LevelName(defLvl), nil
+// SubsystemLevelName returns the current log level name for a given subsystem.
+// An empty name, "", returns the default LogLevel name.
+func SubsystemLevelName(subsys string) (string, error) {
+	if subsys == DefaultName {
+		return DefaultLevel().String(), nil
 	}
-	if lvl, ok := levels[name]; ok {
-		return lvl.Level().String(), nil
+	lvl, ok := levels[subsys]
+	if !ok {
+		return "", ErrNoSuchLogger
 	}
-	return "", ErrNoSuchLogger
+	return lvl.Level().String(), nil
 }
 
-// GetAllLogLevels returns a map of all current log levels for all subsystems as strings.
-// The map includes a special "*" key that represents the defaultLevel.
-func GetAllLogLevels() map[string]string {
+// SubsystemLevelNames returns a map of all facility names to their current log
+// levels as strings. The map includes the default log level identified by the
+// defaultName string as the map key.
+func SubsystemLevelNames() map[string]string {
 	result := make(map[string]string, len(levels)+1)
 
-	// Add the default level with "*" key
-	loggerMutex.RLock()
-	defLvl := defaultLevel
-	loggerMutex.RUnlock()
-	result["*"] = LevelName(defLvl)
+	result[DefaultName] = DefaultLevel().String()
 
-	// Add all subsystem levels
 	for name, level := range levels {
 		result[name] = level.Level().String()
 	}

--- a/setup.go
+++ b/setup.go
@@ -198,7 +198,7 @@ func setAllLoggers(lvl LogLevel) {
 // SetLogLevel changes the log level of a specific subsystem
 // name=="*" changes all subsystems
 func SetLogLevel(name, level string) error {
-	lvl, err := LevelFromString(level)
+	lvl, err := Parse(level)
 	if err != nil {
 		return err
 	}
@@ -226,7 +226,7 @@ func SetLogLevel(name, level string) error {
 // SetLogLevelRegex sets all loggers to level `l` that match expression `e`.
 // An error is returned if `e` fails to compile.
 func SetLogLevelRegex(e, l string) error {
-	lvl, err := LevelFromString(l)
+	lvl, err := Parse(l)
 	if err != nil {
 		return err
 	}
@@ -321,7 +321,7 @@ func configFromEnv() Config {
 	if lvl != "" {
 		for _, kvs := range strings.Split(lvl, ",") {
 			kv := strings.SplitN(kvs, "=", 2)
-			lvl, err := LevelFromString(kv[len(kv)-1])
+			lvl, err := Parse(kv[len(kv)-1])
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "error setting log level %q: %s\n", kvs, err)
 				continue


### PR DESCRIPTION
- LogLevel has a String method to convert the numeric level into its string version
- There is only one name used to identify the default log level, and it is declared as a const `DefaultName`
- Removed the "Get" name for functions that lookup a value.
- A `DefaultLevel` function returns the current log level and handles locking.
- Function to convert string to LogLevel is named `Parse`