### PR TITLE
Require go1.24 as minimum go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ipfs/go-log/v2
 
-go 1.23.8
+go 1.24
 
 require (
 	github.com/mattn/go-isatty v0.0.20


### PR DESCRIPTION
Are we ready to require go1.24 now that go1.25 is out?