### PR TITLE
feat: add LevelEnabled function to check if log level enabled

### DIFF
--- a/log.go
+++ b/log.go
@@ -70,6 +70,11 @@ func (logger *ZapEventLogger) Warningf(format string, args ...interface{}) {
 	logger.skipLogger.Warnf(format, args...)
 }
 
+// LevelEnabled returns true if the LogLevel is enabled for the logger.
+func (logger *ZapEventLogger) LevelEnabled(level LogLevel) bool {
+	return logger.Level().Enabled(zapcore.Level(level))
+}
+
 // FormatRFC3339 returns the given time in UTC with RFC3999Nano format.
 func FormatRFC3339(t time.Time) string {
 	return t.UTC().Format(time.RFC3339Nano)

--- a/log_level_test.go
+++ b/log_level_test.go
@@ -43,8 +43,12 @@ func TestLogLevel(t *testing.T) {
 		}
 	}()
 	logger.Debugw("foo")
+	require.True(t, logger.LevelEnabled(LevelError))
+	require.False(t, logger.LevelEnabled(LevelDebug))
 	err := SetLogLevel(subsystem, "debug")
 	require.NoError(t, err)
+	require.True(t, logger.LevelEnabled(LevelError))
+	require.True(t, logger.LevelEnabled(LevelDebug))
 
 	logger.Debugw("bar")
 	SetAllLoggers(LevelInfo)


### PR DESCRIPTION
Add a LevelEnabled method to the ZapEventLogger to more conveniently check if a log level is enabled for the logger.

This is an alternative to calling:
```go
    logger.Level().Enabled(zapcore.Level(LevelDebug))
```
resulting in the simpler and more readable call to:
```go
    logger.LevelEnabled(LevelDebug)
```

This has the added bebefid of not requiring an import of `"go.uber.org/zap/zapcore"`